### PR TITLE
Created additional table, added x,y label as props and type comments

### DIFF
--- a/src/app/components/BarChart.stories.ts
+++ b/src/app/components/BarChart.stories.ts
@@ -22,6 +22,8 @@ export const Primary: Story<DataTypeA, "artal"> = {
 		yAccessor: (d) => {
 			return d.fjoldi;
 		},
+		xLabel: "Ár",
+		yLabel: "Fjöldi",
 		options: {
 			width: 800,
 			height: 600,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -113,12 +113,8 @@ const data: DataType[] = [
 const dataKarlar = data.filter((item) => item.kyn === "Karlar");
 
 export default function Home() {
-	const width= 872;
-	const height= 662;
 	return (
 		<main className={styles.main}>
-			<div>
-				<h1>D3 Project for Reykjavík</h1>
 			<BarChart
 				title='Data Karlar'
 				data={dataKarlar}
@@ -129,9 +125,10 @@ export default function Home() {
 				yAccessor={(d) => {
 					return d.fjoldi;
 				}}
+				xLabel='Ár'
+				yLabel='Fjöldi'
 				options={{}}
 			/>
-			</div>
 		</main>
 	);
 }


### PR DESCRIPTION
- Added table to show the data in other ways in screen readers - it still has to be styled for Screen readers only
- x,y Label as props since dynamic infering key names for x,y Accessor is overcomplicated
- added some comments to types in a form that is readable for the storybook and automatically added to documentation as an argument description
- deleted title outside of a component on the page since it only adds unnecessary sound pollution during screen reader testing
- added tab index to bars to be able to focus on them
- added a couple of aria-hidden to skip for example reading a bunch of y-axis ticks